### PR TITLE
fix: career pathway nodes rendering outside map container

### DIFF
--- a/e2e/pathway-map.spec.ts
+++ b/e2e/pathway-map.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "./fixtures";
+
+test.describe("Pathway map", () => {
+  test("career nodes render inside the map container, not off-screen", async ({ page }) => {
+    await page.goto("/careers");
+
+    // Wait for the pathway map container
+    const mapContainer = page.getByTestId("pathway-map");
+    await expect(mapContainer).toBeVisible({ timeout: 15_000 });
+    const mapBox = await mapContainer.boundingBox();
+    expect(mapBox).toBeTruthy();
+
+    // Wait for ReactFlow to finish rendering nodes
+    const nodes = page.locator(".react-flow__node");
+    await expect(nodes.first()).toBeVisible({ timeout: 10_000 });
+
+    const count = await nodes.count();
+    expect(count).toBeGreaterThan(0);
+
+    // Every visible node must be inside the map container's bounding box
+    for (let i = 0; i < count; i++) {
+      const nodeBox = await nodes.nth(i).boundingBox();
+      if (!nodeBox) continue;
+
+      expect(
+        nodeBox.x >= mapBox!.x &&
+          nodeBox.y >= mapBox!.y &&
+          nodeBox.x + nodeBox.width <= mapBox!.x + mapBox!.width &&
+          nodeBox.y + nodeBox.height <= mapBox!.y + mapBox!.height,
+        `Node ${i} is outside the pathway map container (node: ${JSON.stringify(nodeBox)}, container: ${JSON.stringify(mapBox)})`,
+      ).toBe(true);
+    }
+  });
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,36 @@
 @import "tailwindcss";
 
+/* ─── ReactFlow overrides ──────────────────────────────────
+   Tailwind v4's @layer-based preflight resets position, height,
+   and overflow on ReactFlow's internal elements. The bundled
+   @import of @xyflow/react/dist/style.css gets hoisted into
+   Tailwind's layer cascade and loses specificity. These un-layered
+   rules restore the critical layout properties ReactFlow needs. */
+@import "@xyflow/react/dist/style.css";
+
+.react-flow {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.react-flow__viewport {
+  pointer-events: none;
+}
+
+.react-flow__node {
+  pointer-events: all;
+  position: absolute;
+}
+
+/* ReactFlow's keyboard-navigation announcements are classless <div>s
+   with inline `display:none` that Tailwind v4's preflight can override.
+   Target them as direct children of .react-flow that have no class. */
+.react-flow > div:not([class]) {
+  display: none !important;
+}
+
 /* Emil Kowalski custom easing curves — snappier than CSS defaults.
    ease-out for enter/exit, ease-in-out for morph/move, ease-drawer for drawers. */
 :root {

--- a/src/components/careers/PathwayMap.tsx
+++ b/src/components/careers/PathwayMap.tsx
@@ -14,7 +14,8 @@ import {
   useReactFlow,
   ReactFlowProvider,
 } from "@xyflow/react";
-import "@xyflow/react/dist/style.css";
+// ReactFlow CSS is imported in globals.css (must come after Tailwind's
+// @import to avoid cascade-layer specificity conflicts in Tailwind v4).
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils";
 import { Badge, SectorBadge } from "@/components/ui/Badge";
@@ -276,7 +277,7 @@ function PathwayMapInner({ careers }: { careers: Career[] }) {
           nodeTypes={nodeTypes}
           onNodeClick={onNodeClick}
           fitView
-          fitViewOptions={{ padding: 0.15 }}
+          fitViewOptions={{ padding: 0.25 }}
           minZoom={0.3}
           maxZoom={1.5}
           proOptions={{ hideAttribution: true }}


### PR DESCRIPTION
## Summary
- Fix Tailwind CSS v4 / ReactFlow CSS cascade conflict where preflight overrides ReactFlow's internal `height: 100%`, `position: relative`, and `overflow: hidden`, causing career nodes to render at raw pixel coordinates outside the map container
- Add explicit un-layered CSS overrides in `globals.css` and hide ReactFlow's classless aria-announcement divs that Tailwind also un-hides
- Bump `fitView` padding from 0.15 → 0.25 for better breathing room
- Add `e2e/pathway-map.spec.ts` that asserts every `.react-flow__node` bounding box is inside the `[data-testid="pathway-map"]` container

## Test plan
- [ ] Verify career pathway map renders all 12 nodes inside the white bordered container on desktop
- [ ] Verify edges/connections are visible between nodes
- [ ] Verify mobile fallback (grouped list) still works at narrow viewports
- [ ] Run `npx playwright test pathway-map` to confirm new E2E test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)