### PR TITLE
fix: enterprise hero CTA anchors to team assessment section

### DIFF
--- a/e2e/enterprise.spec.ts
+++ b/e2e/enterprise.spec.ts
@@ -12,7 +12,7 @@ test.describe("Enterprise page", () => {
 
     const diagnosticCta = page.getByRole("link", { name: /start team assessment/i }).first();
     await expect(diagnosticCta).toBeVisible();
-    await expect(diagnosticCta).toHaveAttribute("href", /\/diagnostic/);
+    await expect(diagnosticCta).toHaveAttribute("href", "#team-assessment");
 
     const trainingCta = page.getByRole("link", { name: /browse training/i }).first();
     await expect(trainingCta).toBeVisible();

--- a/src/components/enterprise/EnterpriseHero.tsx
+++ b/src/components/enterprise/EnterpriseHero.tsx
@@ -26,9 +26,9 @@ export function EnterpriseHero({ locale, dict }: { locale: Locale; dict: Diction
           </p>
 
           <div className="mt-10 flex flex-wrap gap-4">
-            <Link href={`/${locale}/diagnostic`} className={buttonClassName("secondary", "lg")}>
+            <a href="#team-assessment" className={buttonClassName("secondary", "lg")}>
               {dict.enterprise.ctaDiagnostic}
-            </Link>
+            </a>
             <Link
               href={`/${locale}/training`}
               className={buttonClassName(


### PR DESCRIPTION
## Summary
- Changed the "Start Team Assessment" hero button from linking to `/diagnostic` (individual flow) to anchoring to `#team-assessment` on the same enterprise page (group flow)
- The enterprise page should drive users to the team assessment setup form, not the individual diagnostic

## Test plan
- [ ] Navigate to `/en/enterprise` and click "Start Team Assessment" — should scroll to the team assessment section
- [ ] Verify the form (team name, manager email, threshold) is visible after scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)