### PR TITLE
feat: WCAG 2.2 AA contrast guardrails and structural a11y fixes

### DIFF
--- a/src/app/admin/(dashboard)/settings/page.tsx
+++ b/src/app/admin/(dashboard)/settings/page.tsx
@@ -28,6 +28,7 @@ import { Textarea } from "@/components/admin/Textarea";
 import { CURATED_FONTS, DEFAULT_SITE_SETTINGS } from "@/lib/theme-defaults";
 import { getGoogleFontUrl } from "@/lib/fonts";
 import { adminPatch } from "@/hooks/useAdminFetch";
+import { checkPaletteContrast, type ContrastCheck } from "@/lib/wcag-contrast";
 
 interface SiteSettingsForm {
   colorPrimary: string;
@@ -80,10 +81,12 @@ function ColorPicker({
   label,
   value,
   onChange,
+  contrastWarning,
 }: {
   label: string;
   value: string;
   onChange: (v: string) => void;
+  contrastWarning?: ContrastCheck;
 }) {
   return (
     <div className="flex items-center gap-3">
@@ -91,7 +94,7 @@ function ColorPicker({
         type="color"
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="h-10 w-10 cursor-pointer rounded-lg border border-gray-200 p-0.5"
+        className={`h-10 w-10 cursor-pointer rounded-lg border p-0.5 ${contrastWarning && !contrastWarning.passes ? "border-status-error" : "border-gray-200"}`}
       />
       <div className="flex-1">
         <label className="mb-0.5 block text-xs font-medium text-text-secondary">{label}</label>
@@ -101,9 +104,16 @@ function ColorPicker({
             const v = e.target.value;
             if (/^#[0-9a-fA-F]{0,6}$/.test(v)) onChange(v);
           }}
-          className="font-mono text-sm"
+          className={`font-mono text-sm ${contrastWarning && !contrastWarning.passes ? "border-status-error" : ""}`}
           placeholder="#000000"
         />
+        {contrastWarning && !contrastWarning.passes && (
+          <p className="mt-1 text-xs text-status-error">
+            Fails WCAG 2.2 AA ({contrastWarning.ratio.toFixed(1)}:1, needs{" "}
+            {contrastWarning.required}:1). {contrastWarning.usage}. Please contact the development
+            team to update site colours safely.
+          </p>
+        )}
       </div>
     </div>
   );
@@ -118,6 +128,11 @@ export default function AdminSettingsPage() {
   const [success, setSuccess] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [uploading, setUploading] = useState<"logo" | "favicon" | null>(null);
+
+  // WCAG 2.2 AA contrast checks — recomputed on every colour change
+  const contrastChecks = checkPaletteContrast(form);
+  const failedChecks = contrastChecks.filter((c) => !c.passes);
+  const contrastByField = Object.fromEntries(contrastChecks.map((c) => [c.field, c]));
 
   const siteUrl = "https://sowa.skillnetireland.ie";
   const sitemapUrl = `${siteUrl}/sitemap.xml`;
@@ -296,7 +311,12 @@ export default function AdminSettingsPage() {
             <RotateCcw className="mr-1 h-4 w-4" />
             Reset to Defaults
           </Button>
-          <Button variant="primary" size="sm" onClick={handleSave} disabled={saving}>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={handleSave}
+            disabled={saving || failedChecks.length > 0}
+          >
             {saving ? (
               <Loader2 className="mr-1 h-4 w-4 animate-spin" />
             ) : (
@@ -317,6 +337,15 @@ export default function AdminSettingsPage() {
       {error && (
         <div className="mb-4 rounded-lg border border-status-error/30 bg-status-error/5 px-4 py-3 text-sm text-status-error">
           {error}
+        </div>
+      )}
+      {failedChecks.length > 0 && (
+        <div className="mb-4 rounded-lg border border-status-warning/30 bg-status-warning/5 px-4 py-3 text-sm text-text-primary">
+          <strong className="text-status-warning">WCAG 2.2 AA violation</strong>
+          {" — "}
+          {failedChecks.length} colour{failedChecks.length > 1 ? "s do" : " does"} not meet the
+          minimum contrast ratio. Saving is disabled until all colours pass. Please contact the
+          development team to update site colours safely.
         </div>
       )}
 
@@ -474,16 +503,19 @@ export default function AdminSettingsPage() {
                 label="Main"
                 value={form.colorPrimary}
                 onChange={(v) => updateForm("colorPrimary", v)}
+                contrastWarning={contrastByField.colorPrimary}
               />
               <ColorPicker
                 label="Light"
                 value={form.colorPrimaryLight}
                 onChange={(v) => updateForm("colorPrimaryLight", v)}
+                contrastWarning={contrastByField.colorPrimaryLight}
               />
               <ColorPicker
                 label="Dark"
                 value={form.colorPrimaryDark}
                 onChange={(v) => updateForm("colorPrimaryDark", v)}
+                contrastWarning={contrastByField.colorPrimaryDark}
               />
             </div>
             {/* Secondary */}
@@ -493,16 +525,19 @@ export default function AdminSettingsPage() {
                 label="Main"
                 value={form.colorSecondary}
                 onChange={(v) => updateForm("colorSecondary", v)}
+                contrastWarning={contrastByField.colorSecondary}
               />
               <ColorPicker
                 label="Light"
                 value={form.colorSecondaryLight}
                 onChange={(v) => updateForm("colorSecondaryLight", v)}
+                contrastWarning={contrastByField.colorSecondaryLight}
               />
               <ColorPicker
                 label="Dark"
                 value={form.colorSecondaryDark}
                 onChange={(v) => updateForm("colorSecondaryDark", v)}
+                contrastWarning={contrastByField.colorSecondaryDark}
               />
             </div>
             {/* Accent */}
@@ -512,16 +547,19 @@ export default function AdminSettingsPage() {
                 label="Main"
                 value={form.colorAccent}
                 onChange={(v) => updateForm("colorAccent", v)}
+                contrastWarning={contrastByField.colorAccent}
               />
               <ColorPicker
                 label="Light"
                 value={form.colorAccentLight}
                 onChange={(v) => updateForm("colorAccentLight", v)}
+                contrastWarning={contrastByField.colorAccentLight}
               />
               <ColorPicker
                 label="Dark"
                 value={form.colorAccentDark}
                 onChange={(v) => updateForm("colorAccentDark", v)}
+                contrastWarning={contrastByField.colorAccentDark}
               />
             </div>
           </div>

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -6,6 +6,7 @@ import { requireRole, AuthError } from "@/lib/auth-utils";
 import { applyRateLimit, parseBody, errorResponse } from "@/lib/api-utils";
 import { updateSiteSettingsSchema } from "@/lib/validations";
 import { DEFAULT_SITE_SETTINGS } from "@/lib/theme-defaults";
+import { checkPaletteContrast } from "@/lib/wcag-contrast";
 
 export async function GET(request: NextRequest) {
   const rateLimited = applyRateLimit(request);
@@ -57,6 +58,30 @@ export async function PUT(request: NextRequest) {
 
   const parsed = await parseBody(request, updateSiteSettingsSchema);
   if (parsed.error) return parsed.error;
+
+  // Server-side WCAG 2.2 AA contrast enforcement
+  const palette = {
+    colorPrimary: parsed.data.colorPrimary ?? DEFAULT_SITE_SETTINGS.colorPrimary,
+    colorPrimaryLight: parsed.data.colorPrimaryLight ?? DEFAULT_SITE_SETTINGS.colorPrimaryLight,
+    colorPrimaryDark: parsed.data.colorPrimaryDark ?? DEFAULT_SITE_SETTINGS.colorPrimaryDark,
+    colorSecondary: parsed.data.colorSecondary ?? DEFAULT_SITE_SETTINGS.colorSecondary,
+    colorSecondaryLight:
+      parsed.data.colorSecondaryLight ?? DEFAULT_SITE_SETTINGS.colorSecondaryLight,
+    colorSecondaryDark: parsed.data.colorSecondaryDark ?? DEFAULT_SITE_SETTINGS.colorSecondaryDark,
+    colorAccent: parsed.data.colorAccent ?? DEFAULT_SITE_SETTINGS.colorAccent,
+    colorAccentLight: parsed.data.colorAccentLight ?? DEFAULT_SITE_SETTINGS.colorAccentLight,
+    colorAccentDark: parsed.data.colorAccentDark ?? DEFAULT_SITE_SETTINGS.colorAccentDark,
+  };
+  const contrastFailures = checkPaletteContrast(palette).filter((c) => !c.passes);
+  if (contrastFailures.length > 0) {
+    const details = contrastFailures
+      .map((c) => `${c.label}: ${c.ratio.toFixed(1)}:1 (needs ${c.required}:1)`)
+      .join("; ");
+    return errorResponse(
+      `Colours rejected — WCAG 2.2 AA contrast failures: ${details}. Please contact the development team to update site colours safely.`,
+      400,
+    );
+  }
 
   try {
     // Prisma requires Prisma.JsonNull instead of null for nullable Json fields

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -41,15 +41,18 @@ export function Header({ locale, dict }: { locale: Locale; dict: Dictionary }) {
 
             {/* Desktop nav */}
             <nav className="hidden lg:flex items-center gap-1" aria-label={dict.nav.mainNavigation}>
-              {navLinks.map((link) => (
-                <Link
-                  key={link.href}
-                  href={link.href}
-                  className="px-3 py-2 text-sm font-medium text-text-primary rounded-lg hover:bg-surface hover:text-primary transition-colors"
-                >
-                  {link.label}
-                </Link>
-              ))}
+              <ul className="flex items-center gap-1 list-none m-0 p-0">
+                {navLinks.map((link) => (
+                  <li key={link.href}>
+                    <Link
+                      href={link.href}
+                      className="px-3 py-2 text-sm font-medium text-text-primary rounded-lg hover:bg-surface hover:text-primary transition-colors"
+                    >
+                      {link.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
             </nav>
 
             {/* Right side */}

--- a/src/components/ui/SearchInput.tsx
+++ b/src/components/ui/SearchInput.tsx
@@ -12,10 +12,14 @@ const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
   ({ className, onSearch, ...props }, ref) => {
     return (
       <div className={cn("relative", className)}>
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-text-muted" />
+        <Search
+          className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-text-muted"
+          aria-hidden="true"
+        />
         <input
           ref={ref}
           type="search"
+          aria-label="Search"
           className="w-full rounded-lg border border-gray-200 bg-white pl-10 pr-4 py-2.5 text-base text-text-primary placeholder:text-text-muted transition-colors duration-200 focus:border-accent focus:ring-2 focus:ring-accent/20 focus:outline-none"
           onKeyDown={(e) => {
             if (e.key === "Enter" && onSearch) {

--- a/src/lib/wcag-contrast.ts
+++ b/src/lib/wcag-contrast.ts
@@ -39,7 +39,6 @@ export const WCAG_AA_NORMAL = 4.5;
 export const WCAG_AA_LARGE = 3;
 
 const WHITE = "#FFFFFF";
-const TEXT_PRIMARY = "#1A1A2E";
 
 export interface ContrastCheck {
   field: string;

--- a/src/lib/wcag-contrast.ts
+++ b/src/lib/wcag-contrast.ts
@@ -1,0 +1,197 @@
+/**
+ * WCAG 2.2 contrast-ratio utilities.
+ *
+ * Used by the admin colour picker to prevent operators from choosing
+ * colour combinations that break accessibility requirements.
+ */
+
+/** Convert a hex colour (#RRGGBB) to sRGB [0..1] channels. */
+function hexToRgb(hex: string): [number, number, number] {
+  const h = hex.replace("#", "");
+  return [
+    parseInt(h.substring(0, 2), 16) / 255,
+    parseInt(h.substring(2, 4), 16) / 255,
+    parseInt(h.substring(4, 6), 16) / 255,
+  ];
+}
+
+/** WCAG relative luminance (https://www.w3.org/TR/WCAG22/#dfn-relative-luminance). */
+function luminance(hex: string): number {
+  const [r, g, b] = hexToRgb(hex).map((c) =>
+    c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4),
+  );
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/** WCAG contrast ratio between two hex colours, always >= 1. */
+export function contrastRatio(hex1: string, hex2: string): number {
+  const l1 = luminance(hex1);
+  const l2 = luminance(hex2);
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/** Minimum contrast ratio for WCAG 2.2 AA normal text. */
+export const WCAG_AA_NORMAL = 4.5;
+
+/** Minimum contrast ratio for WCAG 2.2 AA large text / UI components. */
+export const WCAG_AA_LARGE = 3;
+
+const WHITE = "#FFFFFF";
+const TEXT_PRIMARY = "#1A1A2E";
+
+export interface ContrastCheck {
+  field: string;
+  label: string;
+  foreground: string;
+  background: string;
+  ratio: number;
+  required: number;
+  passes: boolean;
+  usage: string;
+}
+
+/**
+ * Run WCAG 2.2 AA contrast checks against the full colour palette.
+ *
+ * Checks match how each colour is actually used in the platform:
+ *
+ * - **Dark variants** → used as text on white backgrounds (e.g. `text-secondary-dark`)
+ *   → need 4.5:1 against white (WCAG 1.4.3 – Contrast Minimum)
+ *
+ * - **Main variants** → used as UI-component colours: button fills, badges,
+ *   checkboxes, focus rings, borders. Must be distinguishable from white page bg.
+ *   → need 3:1 against white (WCAG 1.4.11 – Non-text Contrast)
+ *
+ * - **Primary main** also carries white text on primary buttons.
+ *   → need 4.5:1 white-on-primary (WCAG 1.4.3)
+ *
+ * - **Light variants** → used as hover/tint states on buttons and sidebar.
+ *   Primary-light is a dark colour (white text on admin sidebar hover).
+ *   Secondary/accent-light are mid-range (dark text or decorative).
+ *   → need 3:1 against white (WCAG 1.4.11)
+ */
+export function checkPaletteContrast(colors: {
+  colorPrimary: string;
+  colorPrimaryLight: string;
+  colorPrimaryDark: string;
+  colorSecondary: string;
+  colorSecondaryLight: string;
+  colorSecondaryDark: string;
+  colorAccent: string;
+  colorAccentLight: string;
+  colorAccentDark: string;
+}): ContrastCheck[] {
+  const checks: ContrastCheck[] = [];
+
+  const add = (
+    field: string,
+    label: string,
+    fg: string,
+    bg: string,
+    required: number,
+    usage: string,
+  ) => {
+    if (!/^#[0-9a-fA-F]{6}$/.test(fg) || !/^#[0-9a-fA-F]{6}$/.test(bg)) return;
+    const ratio = contrastRatio(fg, bg);
+    checks.push({
+      field,
+      label,
+      foreground: fg,
+      background: bg,
+      ratio,
+      required,
+      passes: ratio >= required,
+      usage,
+    });
+  };
+
+  // ── Dark variants: used as text on white (WCAG 1.4.3 — 4.5:1) ──
+  add(
+    "colorPrimaryDark",
+    "Primary Dark",
+    colors.colorPrimaryDark,
+    WHITE,
+    WCAG_AA_NORMAL,
+    "Text on white background",
+  );
+  add(
+    "colorSecondaryDark",
+    "Secondary Dark",
+    colors.colorSecondaryDark,
+    WHITE,
+    WCAG_AA_NORMAL,
+    "Text on white background",
+  );
+  add(
+    "colorAccentDark",
+    "Accent Dark",
+    colors.colorAccentDark,
+    WHITE,
+    WCAG_AA_NORMAL,
+    "Text on white background",
+  );
+
+  // ── Primary main: white text on primary button (WCAG 1.4.3 — 4.5:1) ──
+  add(
+    "colorPrimary",
+    "Primary",
+    WHITE,
+    colors.colorPrimary,
+    WCAG_AA_NORMAL,
+    "White text on primary button",
+  );
+
+  // ── Secondary & Accent main: UI-component colour (WCAG 1.4.11 — 3:1) ──
+  // Secondary button uses text-primary (dark navy) not white; accent is used
+  // for focus rings, links, and decorative fills — all non-text contrast.
+  add(
+    "colorSecondary",
+    "Secondary",
+    colors.colorSecondary,
+    WHITE,
+    WCAG_AA_LARGE,
+    "Button/badge visibility on white",
+  );
+  add(
+    "colorAccent",
+    "Accent",
+    colors.colorAccent,
+    WHITE,
+    WCAG_AA_LARGE,
+    "Link/focus-ring visibility on white",
+  );
+
+  // ── Light variants: hover/tint states ──
+  // Light variants are used as hover backgrounds on already-visible elements
+  // and decorative fills with opacity. They don't need to meet non-text contrast
+  // on their own, but must not be indistinguishable from white (would break
+  // hover feedback entirely). A 1.5:1 floor catches white/near-white.
+  add(
+    "colorPrimaryLight",
+    "Primary Light",
+    colors.colorPrimaryLight,
+    WHITE,
+    1.5,
+    "Hover feedback visibility",
+  );
+  add(
+    "colorSecondaryLight",
+    "Secondary Light",
+    colors.colorSecondaryLight,
+    WHITE,
+    1.5,
+    "Hover feedback visibility",
+  );
+  add(
+    "colorAccentLight",
+    "Accent Light",
+    colors.colorAccentLight,
+    WHITE,
+    1.5,
+    "Hover feedback visibility",
+  );
+
+  return checks;
+}


### PR DESCRIPTION
## Summary
- Adds real-time WCAG 2.2 AA contrast checking to admin colour settings — blocks saving non-compliant palettes with inline errors directing operators to contact the dev team
- Server-side enforcement on `PUT /api/settings` rejects colours that fail contrast checks (400 response)
- Header nav links wrapped in semantic `<ul>/<li>` (WCAG 1.3.1)
- SearchInput gains `aria-label` and decorative icon marked `aria-hidden` (WCAG 4.1.2)

## Contrast check rules
| Variant | Check | Required ratio |
|---------|-------|----------------|
| Dark (text on white) | WCAG 1.4.3 | 4.5:1 |
| Primary (white text on button) | WCAG 1.4.3 | 4.5:1 |
| Secondary/Accent (UI component) | WCAG 1.4.11 | 3:1 |
| Light (hover feedback) | Visibility floor | 1.5:1 |

## Test plan
- [ ] Verify admin settings page loads with no contrast warnings on default palette
- [ ] Pick a white/near-white colour for any dark variant → inline error appears, save disabled
- [ ] Reset to defaults → warnings clear, save re-enabled
- [ ] Attempt API bypass via `curl PUT /api/settings` with bad colour → 400 rejection
- [ ] Verify header nav renders identically (structural `<ul>/<li>` only)
- [ ] Run `npx vitest run src/__tests__/api/settings.test.ts` → 5/5 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)