### PR TITLE
fix: unwrap paginated envelope in SearchClient and add error handling

### DIFF
--- a/src/app/(frontend)/[locale]/search/SearchClient.tsx
+++ b/src/app/(frontend)/[locale]/search/SearchClient.tsx
@@ -1,12 +1,22 @@
 "use client";
 
 import { useState, useMemo, useCallback, useEffect } from "react";
-import { useSearchParams, useRouter } from "next/navigation";
+import { useSearchParams, useRouter, useParams } from "next/navigation";
 import Link from "next/link";
-import { Search, ArrowRight, FileText } from "lucide-react";
+import { Search, ArrowRight, FileText, AlertCircle } from "lucide-react";
 import { Container } from "@/components/ui/Container";
 import { Badge } from "@/components/ui/Badge";
 import type { SearchResult } from "@/lib/types";
+
+interface SearchResponse {
+  data: SearchResult[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+}
 
 const typeConfig: Record<
   SearchResult["type"],
@@ -22,21 +32,37 @@ const typeConfig: Record<
 export function SearchClient() {
   const searchParams = useSearchParams();
   const router = useRouter();
+  const params = useParams<{ locale: string }>();
+  const locale = params?.locale ?? "en";
   const initialQuery = searchParams.get("q") ?? "";
   const [query, setQuery] = useState(initialQuery);
   const [results, setResults] = useState<SearchResult[]>([]);
+  const [error, setError] = useState<string | null>(null);
 
   // Fetch search results from API
   useEffect(() => {
     if (!query.trim()) {
       setResults([]);
+      setError(null);
       return;
     }
     let cancelled = false;
+    setError(null);
     fetch(`/api/search?q=${encodeURIComponent(query)}`)
-      .then((res) => res.json())
-      .then((data: SearchResult[]) => {
-        if (!cancelled) setResults(data);
+      .then(async (res) => {
+        if (!res.ok) {
+          throw new Error(`Search request failed (${res.status})`);
+        }
+        const json: SearchResponse = await res.json();
+        if (!cancelled) {
+          setResults(Array.isArray(json.data) ? json.data : []);
+        }
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.error("Search fetch failed:", err);
+        setResults([]);
+        setError("We couldn't complete your search. Please try again.");
       });
     return () => {
       cancelled = true;
@@ -57,9 +83,9 @@ export function SearchClient() {
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
       e.preventDefault();
-      router.push(`/search?q=${encodeURIComponent(query)}`, { scroll: false });
+      router.push(`/${locale}/search?q=${encodeURIComponent(query)}`, { scroll: false });
     },
-    [query, router],
+    [query, router, locale],
   );
 
   return (
@@ -104,6 +130,14 @@ export function SearchClient() {
               <Search className="h-12 w-12 text-text-muted/30 mx-auto mb-4" />
               <p className="text-lg text-text-secondary">
                 Start typing to search across all content
+              </p>
+            </div>
+          ) : error ? (
+            <div className="text-center py-16" role="alert">
+              <AlertCircle className="h-12 w-12 text-status-error/60 mx-auto mb-4" />
+              <p className="text-lg text-text-secondary mb-2">{error}</p>
+              <p className="text-sm text-text-muted">
+                If the problem persists, please refresh the page.
               </p>
             </div>
           ) : results.length === 0 ? (


### PR DESCRIPTION
## Summary

The \`/search\` page was broken in two visible ways:
- Typing a query (e.g. \"wind\") showed **no results** in the live-updating area.
- Pressing **Enter** surfaced the global _\"Something went wrong — An unexpected error occurred.\"_ boundary.

Both symptoms shared a single root cause:

\`/api/search\` returns the standard \`{ data, pagination }\` envelope via \`paginatedResponse\` (\`src/app/api/search/route.ts:179\`), but \`SearchClient.tsx\` was casting the JSON body as \`SearchResult[]\` and storing the **envelope object** directly in state. Downstream, \`for (const r of results)\` inside a \`useMemo\` threw \`TypeError: results is not iterable\` **during render**, which propagated to \`global-error.tsx\`.

## Changes

- **Unwrap \`json.data\` from the envelope** — mirrors the existing \`useAdminFetch\` pattern at \`src/hooks/useAdminFetch.ts:57\`.
- **Add \`res.ok\` check + \`.catch()\`** with a scoped, \`role=\"alert\"\` error card so API failures render inline instead of crashing the whole page.
- **Fix handleSubmit locale prefix** — now pushes \`/\${locale}/search?q=...\` instead of \`/search?q=...\`, eliminating the \`Failed to fetch RSC payload\` warning on form submission.
- **Strongly type the response** as \`SearchResponse\` instead of casting.

Single file changed: \`src/app/(frontend)/[locale]/search/SearchClient.tsx\` (+41 / −7).

## Test plan

Verified locally against \`sowa-dev\` preview (all five paths pass, no global error boundary invoked in any case):

- [x] **Predictive path** — Type \"wind\" → \"Found 20 results for 'wind'\" grouped by Career (12), Event (5), News (4), Research. API returns \`{ data, pagination }\` with \`total: 38\`.
- [x] **Enter path** — Submitting the form pushes to \`/en/search?q=wind\`, results persist, no \"Something went wrong\", no RSC-payload warnings.
- [x] **Empty-query path** — Clearing the input reverts to \"Start typing to search across all content\".
- [x] **No-match path** — Typing \`qqqzzzxxx\` shows the clean \"No results for…\" empty state.
- [x] **Error path** — Stubbed \`/api/search\` to return 500 → scoped error card with \`role=\"alert\"\` renders inline; Search page layout remains intact; global \`global-error.tsx\` boundary does **not** fire.
- [x] Prettier-formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)