### PR TITLE
feat: gate prototype behind basic-auth preview wall

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -36,7 +36,93 @@ function buildCsp(nonce: string): string {
 function withCsp(response: NextResponse, nonce: string): NextResponse {
   response.headers.set("Content-Security-Policy", buildCsp(nonce));
   response.headers.set("x-nonce", nonce);
+  // When the prototype is gated behind the preview wall, also de-list it from
+  // search engines — defence-in-depth alongside the 401 returned to bots.
+  if (process.env.PREVIEW_WALL === "true") {
+    response.headers.set("X-Robots-Tag", "noindex, nofollow");
+  }
   return response;
+}
+
+// ---------------------------------------------------------------------------
+// Preview wall (basic-auth gate)
+// ---------------------------------------------------------------------------
+
+// Paths that must remain reachable without basic-auth credentials.
+// /api/cron/* is authenticated by Vercel cron via CRON_SECRET (see vercel.json).
+const PREVIEW_WALL_BYPASS_PREFIXES = ["/api/cron"];
+
+const PREVIEW_WALL_BODY = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>SOWA Prototype — Restricted</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body { font-family: system-ui, -apple-system, sans-serif; max-width: 36rem; margin: 4rem auto; padding: 0 1.5rem; line-height: 1.55; color: #1A1A2E; }
+    h1 { font-size: 1.5rem; margin-bottom: 0.5rem; color: #0C2340; }
+    a { color: #4A90D9; }
+    button { font: inherit; padding: 0.5rem 1rem; border-radius: 0.375rem; border: 1px solid currentColor; background: transparent; cursor: pointer; }
+    @media (prefers-color-scheme: dark) { body { color: #F7F9FC; } h1 { color: #F7F9FC; } }
+  </style>
+</head>
+<body>
+  <h1>This prototype is currently restricted.</h1>
+  <p>The SOWA platform prototype is paused from public access while the tender is under review.</p>
+  <p><button onclick="location.reload()">Try signing in again</button></p>
+</body>
+</html>`;
+
+/**
+ * Check the basic-auth preview wall. Returns a 401 response if the request
+ * should be rejected, or `null` if it should pass through.
+ *
+ * Activated only when `PREVIEW_WALL=true`. Credentials come from `PREVIEW_USER`
+ * and `PREVIEW_PASS`. /api/cron/* is bypassed so Vercel cron keeps working.
+ */
+function checkPreviewWall(request: NextRequest): NextResponse | null {
+  if (process.env.PREVIEW_WALL !== "true") return null;
+
+  const { pathname } = request.nextUrl;
+  if (PREVIEW_WALL_BYPASS_PREFIXES.some((p) => pathname.startsWith(p))) {
+    return null;
+  }
+
+  const user = process.env.PREVIEW_USER;
+  const pass = process.env.PREVIEW_PASS;
+  if (!user || !pass) {
+    return new NextResponse("Preview wall is enabled but credentials are not configured.", {
+      status: 503,
+      headers: {
+        "Cache-Control": "no-store",
+        "X-Robots-Tag": "noindex, nofollow",
+      },
+    });
+  }
+
+  const header = request.headers.get("authorization");
+  if (header?.startsWith("Basic ")) {
+    try {
+      const decoded = atob(header.slice(6));
+      const idx = decoded.indexOf(":");
+      if (idx > -1 && decoded.slice(0, idx) === user && decoded.slice(idx + 1) === pass) {
+        return null;
+      }
+    } catch {
+      // Malformed Authorization header — fall through to 401.
+    }
+  }
+
+  return new NextResponse(PREVIEW_WALL_BODY, {
+    status: 401,
+    headers: {
+      "WWW-Authenticate": 'Basic realm="SOWA Prototype", charset="UTF-8"',
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "no-store",
+      "X-Robots-Tag": "noindex, nofollow",
+    },
+  });
 }
 
 // Paths that are NOT localised — admin UI, API routes, and Next internals.
@@ -67,6 +153,11 @@ function extractLocale(pathname: string): Locale | null {
 }
 
 export async function proxy(request: NextRequest) {
+  // Preview wall runs first: when PREVIEW_WALL=true, every request needs
+  // basic-auth credentials (PREVIEW_USER/PREVIEW_PASS) except /api/cron/*.
+  const wallResponse = checkPreviewWall(request);
+  if (wallResponse) return wallResponse;
+
   const { pathname } = request.nextUrl;
 
   // Generate a per-request nonce for CSP.


### PR DESCRIPTION
## Summary

Tenderer asked for the prototype to be taken offline while the tender is under review. This adds an env-flagged basic-auth gate to the existing Next.js 16 proxy (`src/proxy.ts`) so the site can be paused from public access without redeploying. Trivially reversible by flipping one env var.

- `PREVIEW_WALL=true` activates the wall; unset (or any other value) keeps the site public
- Credentials come from `PREVIEW_USER` / `PREVIEW_PASS`
- `/api/cron/*` bypassed so Vercel cron keeps running (it has its own `CRON_SECRET`)
- `X-Robots-Tag: noindex, nofollow` set on all responses when wall is on — search engines de-list even with stale URLs
- Fails closed with 503 if `PREVIEW_WALL=true` but creds aren't set
- Existing CSP nonce, i18n redirects, `READ_ONLY` kill-switch, and admin-auth logic all run unchanged (after the wall check)

Defence in depth: `/admin/login` sits behind the wall, and NextAuth credentials remain the inner gate for the admin area.

## Vercel setup (do this BEFORE the wall takes effect)

In Project → Settings → Environment Variables, scoped to **Production + Preview**:

| Key | Value |
|---|---|
| `PREVIEW_WALL` | `true` |
| `PREVIEW_USER` | memorable username, e.g. `sowa-tender` |
| `PREVIEW_PASS` | 20+ char random password (share via password manager) |

Leave them unset in Development — the wall stays off for local `npm run dev`.

## Quick disable

Set `PREVIEW_WALL=false` (or delete it) in Vercel — next request is unwalled. No code change needed.

## Test plan

Verified locally with `PREVIEW_WALL=true PREVIEW_USER=evaluator PREVIEW_PASS=test123 npm run dev -- -p 3001`:

- [x] `GET /` no auth → 401 + `WWW-Authenticate: Basic` + `X-Robots-Tag: noindex` + branded HTML body
- [x] `GET /` wrong creds → 401
- [x] `GET /` correct creds → 307 → `/en` with CSP + `X-Robots-Tag: noindex`
- [x] `GET /api/cron/publish` no auth → wall bypassed, cron's own `CRON_SECRET` check runs
- [x] `GET /admin/login` no auth → wall 401 (admin gated by wall too)
- [x] `GET /admin/login` correct creds → 200, NextAuth still required to enter admin
- [x] `npm run type-check` clean
- [x] `npx prettier --check src/proxy.ts` clean
- [ ] Vercel preview shows browser auth prompt and accepts configured creds
- [ ] After merge, production prompt works in incognito

🤖 Generated with [Claude Code](https://claude.com/claude-code)